### PR TITLE
Cw 905

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -235,7 +235,6 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         'location_filter' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone_type_id = " . CRM_Core_PseudoConstant::getKey('CRM_Core_DAO_Phone', 'phone_type_id', 'Mobile')),
         'phone_not_null' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone IS NOT NULL"),
         'phone_not_empty' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.phone != ''"),
-        'is_primary' => CRM_Utils_SQL_Select::fragment()->where("$entityTable.is_primary = 1"),
         'mailing_id' => CRM_Utils_SQL_Select::fragment()->where("mg.mailing_id = #mailingID"),
         'temp_contact_null' => CRM_Utils_SQL_Select::fragment()->where('temp.contact_id IS null'),
         'order_by' => CRM_Utils_SQL_Select::fragment()->orderBy("$entityTable.is_primary = 1"),

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -239,7 +239,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         'temp_contact_null' => CRM_Utils_SQL_Select::fragment()->where('temp.contact_id IS null'),
         'order_by' => CRM_Utils_SQL_Select::fragment()->orderBy("$entityTable.is_primary = 1"),
       );
-    }
+    } 
     else {
       // Criterias to filter recipients that need to be included
       $criteria = array(

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -413,6 +413,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
   public function testgetRecipientsSMS() {
     // Tests for SMS bulk mailing recipients
     // +CRM-21320 Ensure primary mobile number is selected over non-primary
+    // +CUDARW-905 Ensure that a secondary mobile number is selected if the primary can not receive SMS
 
     // Setup
     $smartGroupParams = array(
@@ -441,6 +442,13 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     $this->callAPISuccess('GroupContact', 'Create', array(
       'group_id' => $group,
       'contact_id' => $contactID2,
+    ));
+    
+    // Create contact 3 and add in group
+    $contactID3 = $this->individualCreate(array(), 2);
+    $this->callAPISuccess('GroupContact', 'Create', array(
+      'group_id' => $group,
+      'contact_id' => $contactID3,
     ));
 
     $contactIDPhoneRecords = array(
@@ -477,12 +485,30 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
           'is_primary' => 1,
         ))),
       ),
+      // Create primary that cant recieve SMS but a secondary that can, to test CUDARW-905
+      $contactID3 => array(
+        'other_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', array(
+          'contact_id' => $contactID3,
+          'phone' => "03 01",
+          'location_type_id' => "Home",
+          'phone_type_id' => "Mobile",
+          'is_primary' => 0,
+        ))),
+        'primary_phone_id' => CRM_Utils_Array::value('id', $this->callAPISuccess('Phone', 'create', array(
+          'contact_id' => $contactID3,
+          'phone' => "03 02",
+          'location_type_id' => "Work",
+          'phone_type_id' => "Phone",
+          'is_primary' => 1,
+        ))),
+      ),
     );
 
     // Prepare expected results
     $checkPhoneIDs = array(
       $contactID1 => $contactIDPhoneRecords[$contactID1]['primary_phone_id'],
       $contactID2 => $contactIDPhoneRecords[$contactID2]['primary_phone_id'],
+      $contactID3 => $contactIDPhoneRecords[$contactID3]['other_phone_id'],
     );
 
     // Create mailing
@@ -494,9 +520,9 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     $recipients = $this->callAPISuccess('MailingRecipients', 'get', array('mailing_id' => $mailing['id']));
 
     // Check the count is correct
-    $this->assertEquals(2, $recipients['count'], 'Check recipient count');
+    $this->assertEquals(3, $recipients['count'], 'Check recipient count');
 
-    // Check we got the 'primary' mobile for both contacts
+    // Check we got the 'primary' mobile for contacts or the other phone when the primary was no SMS capable.
     foreach ($recipients['values'] as $value) {
       $this->assertEquals($value['phone_id'], $checkPhoneIDs[$value['contact_id']], 'Check correct phone number for contact ' . $value['contact_id']);
     }
@@ -507,6 +533,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
     $this->groupDelete($group);
     $this->contactDelete($contactID1);
     $this->contactDelete($contactID2);
+    $this->contactDelete($contactID3);
   }
 
   /**

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -443,7 +443,7 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
       'group_id' => $group,
       'contact_id' => $contactID2,
     ));
-    
+
     // Create contact 3 and add in group
     $contactID3 = $this->individualCreate(array(), 2);
     $this->callAPISuccess('GroupContact', 'Create', array(


### PR DESCRIPTION
Overview
----------------------------------------
_Fix for CiviSMS not falling back to non-primary mobile number._

Before
----------------------------------------
_When a contact has a 'home' phone as primary, and a non-primary 'mobile' phone - the non-primary mobile number should be used in a SMS mailout._

After
----------------------------------------
_The query used to decide what numbers should be used has been corrected, so that it allows non-primary mobile numbers to be used - when the primary number is not a mobile._

