### PR TITLE
CW-905

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -239,7 +239,7 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing {
         'temp_contact_null' => CRM_Utils_SQL_Select::fragment()->where('temp.contact_id IS null'),
         'order_by' => CRM_Utils_SQL_Select::fragment()->orderBy("$entityTable.is_primary = 1"),
       );
-    } 
+    }
     else {
       // Criterias to filter recipients that need to be included
       $criteria = array(


### PR DESCRIPTION
Overview
----------------------------------------
_When sending bulk SMS messages to contact with a 'home' phone as primary, and a non-primary 'mobile' phone - CiviSMS should fall back to using the non-primary mobile number in the mailing_

Before
----------------------------------------
_Currently a non-primary mobile phone number is ignored when the primary phone number is not a mobile phone._

After
----------------------------------------
_A non-primary mobile phone number should be used if the primary number is not a mobile phone._

